### PR TITLE
Fix a fatal bug of multiplying size_of::<T> twice in putmem, getmem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ LibBCL/
 core*
 *.iml
 
+test-bench.sh
+test-bench.out

--- a/scaling-test/test-sample-sort/test-bench.out
+++ b/scaling-test/test-sample-sort/test-bench.out
@@ -1,3 +1,4 @@
+2**20
 strong scaling
 N = 1, n = 1, local size = 1048576
 total_time = 118.69221ms

--- a/src/base/global_pointer.rs
+++ b/src/base/global_pointer.rs
@@ -153,7 +153,7 @@ impl<T: Bclable> GlobalPointer<T> {
 
     unsafe fn putmem(&self, target: *mut u8, source: *const u8, len: usize, pe: usize) {
     	if shmemx::my_pe() == self.rank {
-    		libc::memcpy(target as *mut c_void, source as *const T as *const c_void, len * size_of::<T>());
+    		libc::memcpy(target as *mut c_void, source as *const T as *const c_void, len);// * size_of::<T>());
     	} else {
 	        shmemx::shmem_putmem(target, source, len as size_t, self.rank as c_int);
     	}
@@ -161,7 +161,7 @@ impl<T: Bclable> GlobalPointer<T> {
 
     unsafe fn getmem(&self, target: *mut u8, source: *const u8, len: usize, pe: usize) {
     	if shmemx::my_pe() == self.rank {
-    		libc::memcpy(target as *mut c_void, source as *const T as *const c_void, len * size_of::<T>());
+    		libc::memcpy(target as *mut c_void, source as *const T as *const c_void, len);//  * size_of::<T>());
     	} else {
      	   shmemx::shmem_getmem(target, source, len as size_t, self.rank as c_int);
     	}

--- a/src/benchmark/bench_sample_sort.rs
+++ b/src/benchmark/bench_sample_sort.rs
@@ -22,7 +22,7 @@ pub fn benchmark_sample_sort(config: &mut Config) {
     let min_size: usize = 3;
     // output debug info or not
     let mut DBG: bool = true;
-    let mut DETAIL: bool = true;
+    let mut DETAIL: bool = false;
 
     let rankn: usize = config.rankn as usize;
     let rank: usize = config.rank as usize;

--- a/src/benchmark/bench_sample_sort.rs
+++ b/src/benchmark/bench_sample_sort.rs
@@ -79,6 +79,7 @@ pub fn benchmark_sample_sort(config: &mut Config) {
     let start_time_1 = SystemTime::now();
 
     let mut loc_data_serial = loc_data[rank].arget(n);
+    comm::barrier();
     quickersort::sort(&mut loc_data_serial[..]);
     comm::barrier();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,8 +29,8 @@ fn main() {
     let mut config = Config::init(1024);
     let rankn = config.rankn;
 
-    bench_fft::benchmark_fft(&mut config);
-//    bench_sample_sort::benchmark_sample_sort(&mut config);
+//    bench_fft::benchmark_fft(&mut config);
+    bench_sample_sort::benchmark_sample_sort(&mut config);
 //    strong_scaling_queue(&mut config);
 //    weak_scaling_queue(&mut config);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use self::num::complex::{Complex, Complex32, Complex64};
 
 fn main() {
-    let mut config = Config::init(1024);
+    let mut config = Config::init(2048);
     let rankn = config.rankn;
 
 //    bench_fft::benchmark_fft(&mut config);

--- a/test-bench.sh
+++ b/test-bench.sh
@@ -1,20 +1,20 @@
 #!/usr/bin/env bash
 #srun -N 1 -n 6 ./target/release/main
-base_scale=$((2**20))
+base_scale=$((2**23))
 
-#echo "strong scaling" | tee -a "test-bench.out"
+echo "strong scaling" | tee -a "test-bench.out"
 
-#for i in 1 2 4 8 16 32
-#do
-    #echo "N = 1, n = $i, local size = $((${base_scale} / $i))" | tee -a "test-bench.out"
-    #srun -N 1 -n ${i} ./target/release/main $((${base_scale} / $i)) | tee -a "test-bench.out"
-#done
+for i in 1 2 4 8 16 32
+do
+    echo "N = 1, n = $i, local size = $((${base_scale} / $i))" | tee -a "test-bench.out"
+    srun -N 1 -n ${i} ./target/release/main $((${base_scale} / $i)) | tee -a "test-bench.out"
+done
 
-#for i in 1 2 4 8 16 32
-#do
-    #echo "N = $i, n = $(($i *32)), local size = $((${base_scale} / $(($i * 32))))" | tee -a "test-bench.out"
-    #srun -N ${i} -n $(($i *32)) ./target/release/main $((${base_scale} / $(($i * 32)))) | tee -a "test-bench.out"
-#done
+for i in 1 2 4 8 16 32
+do
+    echo "N = $i, n = $(($i *32)), local size = $((${base_scale} / $(($i * 32))))" | tee -a "test-bench.out"
+    srun -N ${i} -n $(($i *32)) ./target/release/main $((${base_scale} / $(($i * 32)))) | tee -a "test-bench.out"
+done
 
 
 echo "weak scaling" | tee -a "test-bench.out"

--- a/test-bench.sh
+++ b/test-bench.sh
@@ -1,20 +1,20 @@
 #!/usr/bin/env bash
 #srun -N 1 -n 6 ./target/release/main
-base_scale=$((2**17))
+base_scale=$((2**20))
 
-echo "strong scaling" | tee -a "test-bench.out"
+#echo "strong scaling" | tee -a "test-bench.out"
 
-for i in 1 2 4 8 16 32
-do
-    echo "N = 1, n = $i, local size = $((${base_scale} / $i))" | tee -a "test-bench.out"
-    srun -N 1 -n ${i} ./target/release/main $((${base_scale} / $i)) | tee -a "test-bench.out"
-done
+#for i in 1 2 4 8 16 32
+#do
+    #echo "N = 1, n = $i, local size = $((${base_scale} / $i))" | tee -a "test-bench.out"
+    #srun -N 1 -n ${i} ./target/release/main $((${base_scale} / $i)) | tee -a "test-bench.out"
+#done
 
-for i in 1 2 4 8 16 32
-do
-    echo "N = $i, n = $(($i *32)), local size = $((${base_scale} / $(($i * 32))))" | tee -a "test-bench.out"
-    srun -N ${i} -n $(($i *32)) ./target/release/main $((${base_scale} / $(($i * 32)))) | tee -a "test-bench.out"
-done
+#for i in 1 2 4 8 16 32
+#do
+    #echo "N = $i, n = $(($i *32)), local size = $((${base_scale} / $(($i * 32))))" | tee -a "test-bench.out"
+    #srun -N ${i} -n $(($i *32)) ./target/release/main $((${base_scale} / $(($i * 32)))) | tee -a "test-bench.out"
+#done
 
 
 echo "weak scaling" | tee -a "test-bench.out"

--- a/test-bench.sh
+++ b/test-bench.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #srun -N 1 -n 6 ./target/release/main
-base_scale=$((2**23))
+base_scale=$((2**20))
 
 echo "strong scaling" | tee -a "test-bench.out"
 
@@ -10,7 +10,7 @@ do
     srun -N 1 -n ${i} ./target/release/main $((${base_scale} / $i)) | tee -a "test-bench.out"
 done
 
-for i in 1 2 4 8 16 32
+for i in 1 2 4 8 16
 do
     echo "N = $i, n = $(($i *32)), local size = $((${base_scale} / $(($i * 32))))" | tee -a "test-bench.out"
     srun -N ${i} -n $(($i *32)) ./target/release/main $((${base_scale} / $(($i * 32)))) | tee -a "test-bench.out"
@@ -25,7 +25,7 @@ do
     srun -N 1 -n ${i} ./target/release/main ${base_scale} | tee -a "test-bench.out"
 done
 
-for i in 1 2 4 8 16 32
+for i in 1 2 4 8 16 
 do
     echo "N = $i, n = $(($i *32)), local size = ${base_scale}" | tee -a "test-bench.out"
     srun -N ${i} -n $(($i *32)) ./target/release/main ${base_scale} | tee -a "test-bench.out"


### PR DESCRIPTION
Fix a fatal bug of multiplying `size_of::<T>()` twice in `putmem`, `getmem`

``` rust
unsafe fn putmem(&self, target: *mut u8, source: *const u8, len: usize, pe: usize) {
    if shmemx::my_pe() == self.rank {
    	  libc::memcpy(target as *mut c_void, source as *const T as *const c_void, len);// * size_of::<T>());
    } else {
	  shmemx::shmem_putmem(target, source, len as size_t, self.rank as c_int);
    }
}

unsafe fn getmem(&self, target: *mut u8, source: *const u8, len: usize, pe: usize) {
   if shmemx::my_pe() == self.rank {
    	libc::memcpy(target as *mut c_void, source as *const T as *const c_void, len);//  * size_of::<T>());
   } else {
     	shmemx::shmem_getmem(target, source, len as size_t, self.rank as c_int);
   }
}
```